### PR TITLE
Update settings menu location in BuildAndSendToTestFairy.java

### DIFF
--- a/src/com/testfairy/plugin/intellij/BuildAndSendToTestFairy.java
+++ b/src/com/testfairy/plugin/intellij/BuildAndSendToTestFairy.java
@@ -152,7 +152,7 @@ public class BuildAndSendToTestFairy extends AnAction {
                         } catch (InterruptedException e1) {
                             Plugin.logException(e1);
                         } catch (TestFairyException tfe) {
-                            Plugin.broadcastError("Invalid TestFairy API key. Please use Build/TestFairy/Settings to fix.");
+                            Plugin.broadcastError("Invalid TestFairy API key. Please use Tools/TestFairy/Settings to fix.");
                         } catch (URISyntaxException e) {
                             Plugin.logException(e);
                         }
@@ -238,7 +238,7 @@ public class BuildAndSendToTestFairy extends AnAction {
                 build.run();
             } catch (GradleConnectionException gce) {
                 if (checkInvalidAPIKey(gce)) {
-                    throw new TestFairyException("Invalid API key. Please use Build/TestFairy/Settings to fix.");
+                    throw new TestFairyException("Invalid API key. Please use Tools/TestFairy/Settings to fix.");
                 }
             } catch (IllegalStateException ise) {
                 throw new TestFairyException(ise.getMessage());


### PR DESCRIPTION
It looks like the menu where you can find the settings has changed from Build to Tools but the error messages weren't updated.
